### PR TITLE
edit-form-page 

### DIFF
--- a/datadoc/templates/datadoc/base.html
+++ b/datadoc/templates/datadoc/base.html
@@ -3,11 +3,13 @@
 <html lang="en">
 
 <head>
-    
     <link rel="icon" href="{% static 'datadoc/favicon.ico' %}" type="image/x-icon">
     <link rel="stylesheet" href="{% static 'datadoc/css/styles.css' %}">
+
+    <!-- Move Bootstrap link here -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,6 +19,9 @@
 
 <body>
     {% block content %}{% endblock %}
+
+    <!-- Move the Bootstrap JavaScript link to the bottom of the body -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/datadoc/templates/datadoc/components/header.html
+++ b/datadoc/templates/datadoc/components/header.html
@@ -2,14 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <!-- Bootstrap CSS from CDN -->
-  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
-
-</head>
-
 <body>
-
   <nav class="navbar navbar-expand-lg navbar-light custom-navbar">
     <div class="container-fluid">
       <a class="navbar-brand custom-link" href="{% url 'explore' %}">
@@ -32,7 +25,7 @@
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
               <a class="dropdown-item" href="/upload-url">Upload via URL</a>
               <a class="dropdown-item" href="/upload-file">Upload File</a>
-              <a class="dropdown-item" href="/edit-form">Edit documentation</a>
+              <a class="dropdown-item" href="/edit-form">Edit Form</a>
             </div>
           </li>
         </div>

--- a/datadoc/templates/datadoc/partials/dropzone.html
+++ b/datadoc/templates/datadoc/partials/dropzone.html
@@ -1,6 +1,6 @@
 <head>
     <meta name="csrf-token" content="{{ csrf_token }}">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    
     <style>
         body {
             font-family: sans-serif;

--- a/datadoc/templates/datadoc/views/edit_form.html
+++ b/datadoc/templates/datadoc/views/edit_form.html
@@ -1,10 +1,243 @@
 {% extends 'datadoc/base.html' %}
-
 {% block content %}
 {% include 'datadoc/components/header.html' %}
 
 <main>
-    <p>This is a simple page to edit</p>
+    <style>
+        .btn-add,
+        .btn-edit,
+        .btn-submit,
+        .btn-delete {
+            background-color: #858885;
+            color: white;
+            border: none;
+        }
 
+        .btn-add:hover,
+        .btn-edit:hover,
+        .btn-submit:hover,
+        .btn-delete:hover {
+            background-color: #3f4140;
+            color: white;
+            border: none;
+        }
+
+        .btn-delete {
+            background-color: #dc3545;
+        }
+
+        .btn-delete:hover {
+            background-color: #c82333;
+        }
+
+        .btn-edit {
+            background-color: #84ff0094;
+        }
+
+        .btn-edit:hover {
+            background-color: #84ff0094;
+        }
+    </style>
+
+    <body class="p-4">
+        <div class="container">
+            <h2 class="mb-4">Documentation Form</h2>
+            <div class="d-flex ">
+                <button type="button" class="btn btn-add me-2" onclick="addColumn()">➕ Add Column</button>
+                <button type="button" class="btn btn-add" onclick="addRow()">➕ Add Row</button>
+            </div>
+
+            <table class="table table-bordered" id="dataTable">
+                <thead>
+                    <tr id="tableHeadings">
+                    </tr>
+                </thead>
+                <tbody id="tableRows">
+                </tbody>
+            </table>
+
+            <div id="submitButtonContainer" class="justify-content-end" style="display: none;">
+                <button type="button" class="btn btn-submit" onclick="generateCSV()">Submit Documentation</button>
+            </div>
+
+        </div>
+
+        <div id="successModal" class="modal fade" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content" id="modalContent">
+                </div>
+            </div>
+        </div>
+
+        <script>
+            let columns = [];
+            let rows = [];
+
+            function addColumn() {
+                const columnName = "Column " + (columns.length + 1);
+                columns.push(columnName);
+                rows.forEach(row => {
+                    row[columnName] = '';
+                });
+                updateTable();
+            }
+
+            function addRow() {
+                if (columns.length === 0) {
+                    alert("Please add at least one column before adding a row.");
+                    return;
+                }
+                const newRow = {};
+                columns.forEach(col => {
+                    newRow[col] = '';
+                });
+                rows.push(newRow);
+                updateTable();
+            }
+
+            function updateTable() {
+                const tableHeadings = document.getElementById('tableHeadings');
+                tableHeadings.innerHTML = '';
+
+                const submitContainer = document.getElementById('submitButtonContainer');
+                const shouldShowButton = columns.length > 0 && rows.length > 0;
+                submitContainer.style.display = shouldShowButton ? 'flex' : 'none';
+
+                columns.forEach((col, colIndex) => {
+                    const th = document.createElement('th');
+                    th.innerHTML = `
+                        <div class="d-flex justify-content-between">
+                            <input type="text" value="${col}" onchange="renameColumn(${colIndex}, this.value)" />
+                            <button class="btn btn-sm btn-outline-danger" onclick="deleteColumn(${colIndex})">🗑️</button>
+                        </div>
+                    `;
+                    tableHeadings.appendChild(th);
+                });
+
+                tableHeadings.appendChild(document.createElement('th'));
+
+                const tableRows = document.getElementById('tableRows');
+                tableRows.innerHTML = '';
+
+                rows.forEach((row, rowIndex) => {
+                    const tr = document.createElement('tr');
+                    columns.forEach(col => {
+                        const td = document.createElement('td');
+                        td.innerHTML = `<input type="text" value="${row[col]}" onchange="updateRowValue(${rowIndex}, '${col}', this.value)" />`;
+                        tr.appendChild(td);
+                    });
+
+                    const actionsTd = document.createElement('td');
+                    const deleteButton = document.createElement('button');
+                    deleteButton.classList.add('btn', 'btn-sm', 'btn-outline-danger');
+                    deleteButton.innerHTML = '🗑️';
+                    deleteButton.onclick = () => {
+                        rows.splice(rowIndex, 1);
+                        updateTable();
+                    };
+                    actionsTd.appendChild(deleteButton);
+                    tr.appendChild(actionsTd);
+                    tableRows.appendChild(tr);
+                });
+            }
+
+            function renameColumn(colIndex, newName) {
+                const oldName = columns[colIndex];
+                columns[colIndex] = newName;
+
+                rows.forEach(row => {
+                    row[newName] = row[oldName];
+                    delete row[oldName];
+                });
+
+                updateTable();
+            }
+
+            function deleteColumn(colIndex) {
+                const colName = columns[colIndex];
+                columns.splice(colIndex, 1);
+                rows.forEach(row => {
+                    delete row[colName];
+                });
+
+                updateTable();
+            }
+
+            function updateRowValue(rowIndex, colName, newValue) {
+                rows[rowIndex][colName] = newValue;
+            }
+
+            function validateTable() {
+                for (let i = 0; i < rows.length; i++) {
+                    for (let j = 0; j < columns.length; j++) {
+                        if (!rows[i][columns[j]]) {
+                            alert("Please fill in all fields before saving the CSV.");
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+
+            function generateCSV() {
+                if (!validateTable()) {
+                    return;
+                }
+                if (columns.length === 0 || rows.length === 0) {
+                    alert("Please add some columns and rows first!");
+                    return;
+                }
+                let csvContent = columns.join(",") + "\n";
+                rows.forEach(row => {
+                    const rowValues = columns.map(col => row[col]);
+                    csvContent += rowValues.join(",") + "\n";
+                });
+                fetch('{% url "process_csv" %}', {
+                    method: 'POST',
+                    headers: {
+                        'HX-Request': 'true',
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: `csv_data=${encodeURIComponent(csvContent)}`
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        showModal(data);
+                    })
+            }
+
+            function showModal(response) {
+                const modalElement = document.getElementById('successModal');
+                const modalContent = document.getElementById('modalContent');
+
+                modalContent.innerHTML = `
+                    <div class="modal-header">
+                        <h5 class="modal-title">${response.status === 'Success' ? 'Success' : 'Error'}</h5>
+                    </div>
+                    <div class="modal-body">
+                        <p>${response.message}</p>
+                        <p>Status Code: ${response.status_code}</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" onclick="closeModal()">Close</button>
+                    </div>
+                `;
+
+                const modalInstance = new bootstrap.Modal(modalElement);
+                modalInstance.show();
+            }
+
+            function closeModal() {
+                columns = [];
+                rows = [];
+                updateTable();
+                document.getElementById('tableHeadings').innerHTML = '';
+                document.getElementById('tableRows').innerHTML = '';
+                document.getElementById('modalContent').innerHTML = '';
+                document.getElementById('submitButtonContainer').style.display = 'none';
+            }
+        </script>
+
+    </body>
 </main>
 {% endblock %}

--- a/datadoc/tests/templates/views/test_edit_form.py
+++ b/datadoc/tests/templates/views/test_edit_form.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class EditFormViewTests(TestCase):
+    def test_documentation_form_renders_correctly(self):
+        url = reverse("edit_form")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(response, "➕ Add Column")
+        self.assertContains(response, "➕ Add Row")
+        self.assertContains(response, "Submit Documentation")
+
+        self.assertContains(response, 'id="successModal"')
+        self.assertContains(response, "<script>", count=1)
+
+        self.assertContains(response, "function addColumn()")
+        self.assertContains(response, "function generateCSV()")
+        self.assertContains(response, "function addRow()")

--- a/datadoc/tests/views/test_csv_form.py
+++ b/datadoc/tests/views/test_csv_form.py
@@ -1,0 +1,56 @@
+import os
+from django.conf import settings
+from django.test import TestCase, Client
+from django.urls import reverse
+from unittest.mock import patch
+from django.http import JsonResponse
+
+
+class ProcessCSVTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.process_csv_url = reverse("process_csv")
+
+    @patch("datadoc.views.get_triplestore")
+    @patch("datadoc.views.process_csv_form")
+    def test_process_valid_csv_data(self, mock_process_csv_form, mock_get_triplestore):
+        csv_data = "@id,@type\nsemdata:77600-23-001_5kV_400x_m001,sem:SEMImage\nsemdata:77600-23-001_5kV_400x_m002,sem:SEMImage"
+
+        mock_get_triplestore.return_value = "mock_ts"
+        mock_process_csv_form.return_value = JsonResponse(
+            {
+                "status": "Success",
+                "message": "CSV processed successfully",
+                "status_code": 200,
+            },
+            status=200,
+        )
+
+        response = self.client.post(self.process_csv_url, {"csv_data": csv_data})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        print("Valid CSV Response:", data)
+        self.assertEqual(data["status"], "Success")
+
+    @patch("datadoc.views.get_triplestore")
+    @patch("datadoc.views.process_csv_form")
+    def test_process_invalid_csv_data(
+        self, mock_process_csv_form, mock_get_triplestore
+    ):
+        csv_data = "name|age\nAlice|30\nBob|25"  # Invalid delimiter
+
+        mock_get_triplestore.return_value = "mock_ts"
+        mock_process_csv_form.return_value = JsonResponse(
+            {
+                "status": "Exception",
+                "message": "Invalid CSV format",
+                "status_code": 500,
+            },
+            status=500,
+        )
+
+        response = self.client.post(self.process_csv_url, {"csv_data": csv_data})
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        print("Invalid CSV Response:", data)
+        self.assertEqual(data["status"], "Exception")

--- a/datadoc/tests/views/test_upload_file_urls.py
+++ b/datadoc/tests/views/test_upload_file_urls.py
@@ -1,0 +1,76 @@
+import os
+from django.conf import settings
+from django.test import TestCase, Client
+from django.urls import reverse
+from unittest.mock import patch
+from django.http import JsonResponse
+
+
+class FileURLUploadTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.upload_url = reverse("upload_file_url")
+
+    @patch("datadoc.views.get_triplestore")
+    @patch("datadoc.views.handle_file_url")
+    def test_upload_json_url(self, mock_handle_file_url, mock_get_triplestore):
+        dummy_url = "https://raw.githubusercontent.com/EMMC-ASBL/datadocweb/refs/heads/main/core/static/core/templates/template.json"
+
+        # Mock Triplestore and response
+        mock_get_triplestore.return_value = "mock_ts"
+        mock_handle_file_url.return_value = JsonResponse(
+            {
+                "status": "Success",
+                "message": "Mocked JSON file processed",
+                "status_code": 200,
+            },
+            status=200,
+        )
+
+        response = self.client.post(self.upload_url, {"url": dummy_url})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        print("JSON URL Upload Response:", data)
+        self.assertEqual(data["status"], "Success")
+
+    @patch("datadoc.views.get_triplestore")
+    @patch("datadoc.views.handle_file_url")
+    def test_upload_csv_url(self, mock_handle_file_url, mock_get_triplestore):
+        dummy_url = "https://raw.githubusercontent.com/EMMC-ASBL/datadocweb/refs/heads/main/core/static/core/templates/template.csv"
+
+        mock_get_triplestore.return_value = "mock_ts"
+        mock_handle_file_url.return_value = JsonResponse(
+            {
+                "status": "Success",
+                "message": "Mocked CSV file processed",
+                "status_code": 200,
+            },
+            status=200,
+        )
+
+        response = self.client.post(self.upload_url, {"url": dummy_url})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        print("CSV URL Upload Response:", data)
+        self.assertEqual(data["status"], "Success")
+
+    @patch("datadoc.views.get_triplestore")
+    @patch("datadoc.views.handle_file_url")
+    def test_upload_yaml_url(self, mock_handle_file_url, mock_get_triplestore):
+        dummy_url = "https://raw.githubusercontent.com/EMMC-ASBL/datadocweb/refs/heads/main/core/static/core/templates/template.yaml"
+
+        mock_get_triplestore.return_value = "mock_ts"
+        mock_handle_file_url.return_value = JsonResponse(
+            {
+                "status": "Success",
+                "message": "Mocked YAML file processed",
+                "status_code": 200,
+            },
+            status=200,
+        )
+
+        response = self.client.post(self.upload_url, {"url": dummy_url})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        print("YAML URL Upload Response:", data)
+        self.assertEqual(data["status"], "Success")

--- a/datadoc/urls.py
+++ b/datadoc/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("download/<str:filename>/", views.download_template, name="download_template"),
     path("upload/file/", views.upload_files, name="upload_files"),
     path("upload/url/", views.upload_file_url, name="upload_file_url"),
+    path("process-csv/", views.process_csv, name="process_csv"),
 ]

--- a/datadoc/utils.py
+++ b/datadoc/utils.py
@@ -1,5 +1,6 @@
 """Util module for datadoc and Django"""
 
+import string
 from typing import Callable, Optional
 import os
 from pathlib import Path
@@ -36,8 +37,8 @@ def get_filetype(filemame: str) -> str:
 
 
 def json_response(status: str, message: str = "", status_code: int = None):
-    """ Return a JsonResponse with status code selected based on status string
-        and included in the response body.
+    """Return a JsonResponse with status code selected based on status string
+    and included in the response body.
     """
     if isinstance(status_code, int):
         resolved_status_code = status_code
@@ -174,6 +175,25 @@ def process_with_temp_file(
         return processing_func(temp_file_path, ts)
     except Exception as e:
         return json_response("Exception", str(e))
+    finally:
+        if temp_file_path and os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+
+
+def process_csv_form(csv_data: str, ts: Triplestore):
+    temp_file_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            delete=False, mode="w", newline=""
+        ) as temp_file:
+            temp_file.write(csv_data)
+            temp_file_path = temp_file.name
+            temp_file.close()
+        return write_csv(temp_file_path, ts)
+
+    except Exception as e:
+        return json_response("Exception", str(e))
+
     finally:
         if temp_file_path and os.path.exists(temp_file_path):
             os.remove(temp_file_path)

--- a/datadoc/views.py
+++ b/datadoc/views.py
@@ -2,13 +2,18 @@
 
 from pathlib import Path
 import mimetypes
-
 from django.conf import settings
 from django.shortcuts import render
 from django.http import FileResponse, Http404
 from django.views.decorators.csrf import csrf_exempt
 
-from .utils import json_response, get_triplestore, handle_file, handle_file_url
+from .utils import (
+    json_response,
+    get_triplestore,
+    handle_file,
+    handle_file_url,
+    process_csv_form,
+)
 
 
 def index(request):
@@ -69,3 +74,11 @@ def upload_file_url(request):
         url = request.POST.get("url")
         ts = get_triplestore(settings.DATADOCWEB["triplestore"])
         return handle_file_url(url, ts)
+
+
+@csrf_exempt
+def process_csv(request):
+    if request.method == "POST":
+        csv_data = request.POST.get("csv_data")
+        ts = get_triplestore(settings.DATADOCWEB["triplestore"])
+        return process_csv_form(csv_data, ts)


### PR DESCRIPTION
A dynamic table , please use just this to test - @id and @type with one row is enough to test.
Tripper doesn't give proper errors so when we add random values without @type or @id it gives an error that is no understandable. 

<img width="1567" height="781" alt="image" src="https://github.com/user-attachments/assets/70b02231-289a-40e5-bf92-0eb1fab983b6" />

w.r.t the search to add existing prefixes, uri's keywords  etc , apparently that needs to be implemented- maybe in tripper or somewhere locally - need to decide.
keywords: https://emmc-asbl.github.io/tripper/latest/datadoc/keywords/#special-keywords-from-json-ld
prefixes: https://emmc-asbl.github.io/tripper/latest/datadoc/prefixes/   



will need a meeting to plan the next steps and clarify and plan on how to implement the below points mentioned by Jesper: 
- The keywords are a representation of selected vocabularies and ontologies that could be stored in the KB. The intension is to make a tool that can generate the keyword files. Before we have that, we have to write the keyword files by hand. 
- Prefixes are formally local. But it would probably be useful to store them in the KB. We can use vann:preferredNamespacePrefix for that